### PR TITLE
GITHUB-15: add TestNG methods' navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,17 @@
 
 IntelliJ IDEA integration for [Test Data Supplier](https://github.com/sskorol/test-data-supplier) library.
 
-Currently plugin provides very simple inspections support to determine methods annotated with **DataSupplier** (DS) annotation, so that you could easily track missing DS errors, and avoid unused methods' warnings.
+Currently, plugin provides very simple inspections support to determine methods annotated with **DataSupplier** (DS) annotation, so that you could easily track missing DS errors and avoid unused methods' warnings.
 
-Apart from that, you'll be able to navigate to specified **dataProvider** in **Test** and **Factory** annotations.
+Available features:
+- Missing DS will be marked red for **Test** and **Factory** annotations.
+- Clicking **dataProvider** arg value will trigger navigation to corresponding DS and vice versa.
+- Clicking test name within **include** tag of TestNG xml or test class will trigger cross navigation as well.
 
-Future releases may include more features: duplicates checks and bi-directional navigation.
+Note that to avoid clashes with integrated **TestNG** plugin you have to disable native **DataProvider** inspections:
 
-Note that to avoid clashes with integrated TestNG plugin, you have to disable common DataProvider inspections:
+![ds-settings](https://user-images.githubusercontent.com/6638780/163784461-9f60dd23-470c-47e3-9631-1392f5e518db.gif)
 
-![image](https://user-images.githubusercontent.com/6638780/28659256-80fc5222-72b7-11e7-83bf-896b205c0527.png)
+After plugin installation you'll be able to see the following inspections and navigation options:
 
-After plugin installation, you'll be able to see the following inspections:
-
-![image](https://user-images.githubusercontent.com/6638780/28659976-eaa2f79c-72b9-11e7-802a-17d34fbfdb98.png)
-
- - Missing DS will be marked red for **Test** and **Factory** annotations.
- - Clicking **dataProvider** arg value will trigger navigation to corresponding DS.
+![ds-nav](https://user-images.githubusercontent.com/6638780/163788225-30a5c91d-def1-4ed4-8a17-2ff90776b045.gif)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@
 
 pluginGroup = io.github.sskorol
 pluginName = Test Data Supplier
-pluginVersion = 0.3.3
-changeNotes = Release 0.3.3:<br>Migrated to IntelliJ 2022.1 version.<br><br>
+pluginVersion = 0.4.0
+changeNotes = Release 0.4.0:<br>Added TestNG methods' navigator between xml and Java classes. Changed search scopes from all to module.<br><br>
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/io/github/sskorol/core/TestNGTestCaseReferenceContributor.java
+++ b/src/main/java/io/github/sskorol/core/TestNGTestCaseReferenceContributor.java
@@ -1,0 +1,35 @@
+package io.github.sskorol.core;
+
+import com.intellij.patterns.XmlAttributeValuePattern;
+import com.intellij.psi.*;
+import com.intellij.psi.xml.XmlAttributeValue;
+import com.intellij.util.ProcessingContext;
+import io.github.sskorol.utils.TestCaseReference;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.patterns.XmlPatterns.*;
+
+public class TestNGTestCaseReferenceContributor extends PsiReferenceContributor {
+
+    private static final XmlAttributeValuePattern TEST_CASE_PATTERN =
+            xmlAttributeValue(xmlAttribute("name")
+                    .withParent(xmlTag().withName("include")
+                            .withParent(xmlTag().withName("methods")
+                                    .withParent(xmlTag().withName("class")
+                                            .withParent(xmlTag().withName("classes")
+                                                    .withParent(xmlTag().withName("test")
+                                                            .withParent(xmlTag().withName("suite"))))))));
+
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        registrar.registerReferenceProvider(TEST_CASE_PATTERN, new PsiReferenceProvider() {
+            @NotNull
+            public PsiReference[] getReferencesByElement(
+                    @NotNull final PsiElement element,
+                    @NotNull final ProcessingContext context
+            ) {
+                return new TestCaseReference[]{new TestCaseReference((XmlAttributeValue) element)};
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/sskorol/utils/TestCaseReference.java
+++ b/src/main/java/io/github/sskorol/utils/TestCaseReference.java
@@ -1,0 +1,64 @@
+package io.github.sskorol.utils;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.psi.*;
+import com.intellij.psi.xml.*;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static com.intellij.psi.search.GlobalSearchScope.moduleScope;
+import static java.util.Optional.ofNullable;
+
+public class TestCaseReference extends PsiReferenceBase<XmlAttributeValue> {
+
+    public TestCaseReference(final XmlAttributeValue element) {
+        super(element, false);
+    }
+
+    @Override
+    public PsiElement bindToElement(final @NotNull PsiElement element) throws IncorrectOperationException {
+        return element instanceof PsiMethod
+                ? handleElementRename(((PsiMethod) element).getName())
+                : super.bindToElement(element);
+    }
+
+    @Nullable
+    public PsiElement resolve() {
+        return Stream.iterate(getElement().getParent(), element -> element instanceof XmlTag || element instanceof XmlAttribute, PsiElement::getParent)
+                .filter(element -> element instanceof XmlTag)
+                .map(element -> (XmlTag) element)
+                .filter(tag -> tag.getLocalName().equals("class"))
+                .map(tag -> tag.getAttribute("name"))
+                .filter(Objects::nonNull)
+                .map(XmlAttribute::getValue)
+                .filter(Objects::nonNull)
+                .map(this::findMethod)
+                .findFirst()
+                .orElse(getElement());
+    }
+
+    private PsiElement findMethod(final String className) {
+        final PsiElement parent = getElement().getParent();
+        final String methodName = ofNullable(((XmlAttribute) parent).getValue()).orElse("");
+        final Project project = parent.getProject();
+        final Module module = ProjectRootManager.getInstance(project)
+                .getFileIndex()
+                .getModuleForFile(parent.getContainingFile().getVirtualFile());
+
+        if (module == null) {
+            return getElement();
+        }
+
+        return ofNullable(JavaPsiFacade.getInstance(project).findClass(className, moduleScope(module)))
+                .map(psiClass -> psiClass.findMethodsByName(methodName, false))
+                .filter(methods -> methods.length > 0)
+                .map(methods -> (PsiElement) methods[0])
+                .orElse(getElement());
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,8 @@
     <extensions defaultExtensionNs="com.intellij">
         <psi.referenceContributor language="JAVA"
                                   implementation="io.github.sskorol.core.DataProviderReferenceContributor"/>
+        <psi.referenceContributor language="XML"
+                                  implementation="io.github.sskorol.core.TestNGTestCaseReferenceContributor"/>
         <methodReferencesSearch implementation="io.github.sskorol.core.DataSupplierSearcher"/>
         <localInspection groupPath="Java"
                          language="JAVA"


### PR DESCRIPTION
- Added new test case reference contributor to perform flexible navigation between TestNG xml includes and java tests.
- Changed search scope for data supplier from all to module to fix potential navigation issues in multi-module projects.
- Updated README with recent updates and more interactive images.

Fixes #15 